### PR TITLE
chore: build nuget package that fixes 7.0.3 crash

### DIFF
--- a/Branch-Xamarin-SDK/Model/BranchUniversalObject.cs
+++ b/Branch-Xamarin-SDK/Model/BranchUniversalObject.cs
@@ -148,8 +148,7 @@ namespace BranchXamarinSDK
             {
                 if (data["metadata"] != null)
                 {
-                    //Dictionary<string, object> metaTemp = data["metadata"] as Dictionary<string, object>;
-                    Dictionary<string, object> metaTemp = JsonConvert.DeserializeObject<Dictionary<string, object>>(data["metadata"] as string);
+                    Dictionary<string, object> metaTemp = data["metadata"] as Dictionary<string, object>;
 
                     if (metaTemp != null)
                     {

--- a/NuGet/Branch-Xamarin-SDK.nuspec
+++ b/NuGet/Branch-Xamarin-SDK.nuspec
@@ -4,7 +4,7 @@
     <id>Branch-Xamarin-Linking-SDK</id>
     <title>Branch Xamarin SDK</title>
     <summary>Hosted deep links for your Xamarin-based Android or iOS app by Branch</summary>
-    <version>7.0.3</version>
+    <version>7.0.4</version>
     <authors>Branch Metrics, Inc.</authors>
     <owners>Branch Metrics, Inc.</owners>
 <!--     <iconUrl> https://s3-us-west-1.amazonaws.com/branchhost/branch_icon.png</iconUrl> -->


### PR DESCRIPTION
Fix issue casting `data["metadata"]` to string by reverting the specific piece of code related.
https://github.com/BranchMetrics/xamarin-branch-deep-linking-attribution/issues/126

Affected users will need to manually install `NuGet/Branch-Xamarin-Linking-SDK.7.0.4.nupkg`