### PR TITLE
Fix typo that added shipping value to revenue on events

### DIFF
--- a/Branch-Xamarin-SDK.Droid/BranchAndroidUtils.cs
+++ b/Branch-Xamarin-SDK.Droid/BranchAndroidUtils.cs
@@ -219,7 +219,7 @@ namespace BranchXamarinSDK.Droid
             }
 
             if (parameters.Has("shipping")) {
-                branchEvent.SetRevenue(parameters.GetDouble("shipping"));
+                branchEvent.SetShipping(parameters.GetDouble("shipping"));
             }
 
             if (parameters.Has("search_query")) {

--- a/NuGet/Branch-Xamarin-SDK.nuspec
+++ b/NuGet/Branch-Xamarin-SDK.nuspec
@@ -4,7 +4,7 @@
     <id>Branch-Xamarin-Linking-SDK</id>
     <title>Branch Xamarin SDK</title>
     <summary>Hosted deep links for your Xamarin-based Android or iOS app by Branch</summary>
-    <version>7.0.4</version>
+    <version>7.0.5</version>
     <authors>Branch Metrics, Inc.</authors>
     <owners>Branch Metrics, Inc.</owners>
 <!--     <iconUrl> https://s3-us-west-1.amazonaws.com/branchhost/branch_icon.png</iconUrl> -->


### PR DESCRIPTION
Fix issue that added shipping value to revenue on events
https://github.com/BranchMetrics/xamarin-branch-deep-linking-attribution/issues/128

Affected users can manually install NuGet/Branch-Xamarin-Linking-SDK.7.0.5.nupkg