### PR TITLE
[SDK-1498] Fixed package compatibility warnings

### DIFF
--- a/NuGet/Branch-Xamarin-SDK.nuspec
+++ b/NuGet/Branch-Xamarin-SDK.nuspec
@@ -14,14 +14,14 @@
     <tags>Xamarin Branch deep linking tracking measurement iOS Android sharing referral invite analytics</tags>
     <dependencies>
       <group targetFramework=".NETStandard1.2" >
-        <dependency id="Newtonsoft.Json" version="13.*" />
+        <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
       <group targetFramework="MonoAndroid" >
-        <dependency id="Newtonsoft.Json" version="13.*" />
-	<dependency id="Xamarin.Android.Binding.InstallReferrer" version="2.*" />
+        <dependency id="Newtonsoft.Json" version="13.0.1" />
+	<dependency id="Xamarin.Android.Binding.InstallReferrer" version="2.2.0" />
       </group>
       <group targetFramework="Xamarin.iOS10" >
-        <dependency id="Newtonsoft.Json" version="13.*" />
+        <dependency id="Newtonsoft.Json" version="13.0.1" />
       </group>
     </dependencies>    
     <license type="file">LICENSE.txt</license>


### PR DESCRIPTION
[SDK-1498] Branch Xamarin Linking SDK reports unnecessary compatibility warnings
https://branch.atlassian.net/browse/SDK-1498

### Description
The SDK would show warnings that a specific version of a package wasn't found and the nearest one was chosen. To fix this, we specified the version of the package we want to use.

### Testing
Add the SDK to an app and run it. You shouldn't see any warnings related to code NU1603.

[SDK-1498]: https://branch.atlassian.net/browse/SDK-1498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ